### PR TITLE
Update trait.process.R

### DIFF
--- a/R/trait.process.R
+++ b/R/trait.process.R
@@ -68,13 +68,13 @@
 #' ## The Brownian motion process
 #' BM.process(x0 = 0)
 #' plot(make.traits(process = BM.process))
-#' ## A correlation matrix between 3 traits
-#' cor_matrix <- matrix(c(1/3,1/3,1/3,1/3,2/3,0,1/3,0,2/3), ncol = 3)
-#' BM.process(x0 = c(0,0,0), Sigma = cor_matrix)
+#' ## A covariance matrix between 3 traits
+#' varcovar_matrix <- matrix(c(1/3,1/3,1/3,1/3,2/3,0,1/3,0,2/3), ncol = 3)
+#' BM.process(x0 = c(0,0,0), Sigma = varcovar_matrix)
 #' 
 #' ## The Ornstein-Uhlenbeck process
 #' OU.process(x0 = 0)
-#' plot(make.traits(process = BM.process))
+#' plot(make.traits(process = OU.process))
 #' 
 #' ## No process
 #' no.process()
@@ -104,15 +104,15 @@ trait.process <- function(x0 = 0, edge.length = 1, ...) {
 
 ## The Brownian motion
 BM.process <- function(x0 = 0, edge.length = 1, Sigma = diag(length(x0)), ...) {
-    return(t(MASS::mvrnorm(n = 1, mu = x0, Sigma = sqrt(Sigma^2 * edge.length), ...)))
+    return(t(MASS::mvrnorm(n = 1, mu = x0, Sigma = Sigma * edge.length, ...)))
 }
 
 ## The OU process
 OU.process <- function(x0 = 0, edge.length = 1, Sigma = diag(length(x0)), alpha = 1, optimum = 0, ...) {
     ## Calculate the means
-    means <- optimum + (x0 - optimum) * exp(-alpha)
+    means <- optimum + (x0 - optimum) * exp(-alpha * edge.length)
     ## Calculate the Sigma
-    Sigma <- Sigma/(2 * alpha) * (1 - exp(-2 * alpha))
+    Sigma <- Sigma/(2 * alpha) * (1 - exp(-2 * alpha * edge.length))
     ## Get the traits
     return(t(MASS::mvrnorm(n = 1, mu = means, Sigma = Sigma * edge.length, ...)))
 }
@@ -138,9 +138,9 @@ multi.peak.process <- function(x0 = 0, edge.length = 1, Sigma = diag(length(x0))
     }
     
     ## Calculate the means
-    means <- theta + (x0 - theta) * exp(-alpha)
+    means <- theta + (x0 - theta) * exp(-alpha * edge.length)
     ## Calculate the Sigma
-    Sigma <- Sigma/(2 * alpha) * (1 - exp(-2 * alpha))
+    Sigma <- Sigma/(2 * alpha) * (1 - exp(-2 * alpha * edge.length))
     ## Get the traits
     return(t(MASS::mvrnorm(n = 1, mu = means, Sigma = Sigma * edge.length, ...)))
 }


### PR DESCRIPTION
I think the equations used for the BM and OU processes need to be updated. For the BM process, mvrnorm expects a variance-covariance matrix Sigma, not a correlation matrix so no squaring is required- we should just sample from Sigma*edge.length. For the OU process, the expected mean and variance of an OU process should depend on edge.length (i.e time), so that they decay to the OU optimum and the stationary variance respectively as time goes to infinity. For the same reason I made changes to the multi-peak model. In its current form the OU process model only allows for a single alpha across all traits. Also, the assumption that the OU process can be modelled as a sample from a multivariate normal distribution only holds asymptotically as time goes to infinity. Therefore, you may wish to consider incorporating an OU model from another package that does this exactly rather than using an approximation.